### PR TITLE
Fixes related to the redesign of the Default activity completion page in Moodle 4.3 (MDL-78528)

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -34,7 +34,13 @@ class mod_turnitintooltwo_mod_form extends moodleform_mod {
     private $turnitintooltwo;
 
     public function definition() {
-        global $DB, $USER, $COURSE;
+        global $DB, $USER, $COURSE, $PAGE;
+
+        // Abort if output of page has begun as otherwise it will break page.
+        // This is most likely because of the redesign of the Default activity completion page in Moodle 4.3 (MDL-78528).
+        if ($PAGE->state > 0) {
+            return false;
+        }
 
         // Module string is useful for product support.
         $modulestring = '<!-- Turnitin Moodle Direct Version: '.turnitintooltwo_get_version().' - (';


### PR DESCRIPTION
Now checking if page output has already behun and if so aborting definition() in mod_form.php.
This no longer requires for moving requiring custom jQuery from mod_form.php to view.php - so it has been reverted.
This will fix https://github.com/turnitin/moodle-mod_turnitintooltwo/issues/704 and https://github.com/turnitin/moodle-mod_turnitintooltwo/issues/706

