### PR TITLE
Provide correct return type in Soap class method to avoid warning with PHP 8.1

### DIFF
--- a/sdk/soap.class.php
+++ b/sdk/soap.class.php
@@ -283,7 +283,7 @@ class Soap extends SoapClient {
         parent::__construct( $wsdl, $options );
     }
 
-    public function __doRequest($request, $location, $action, $version, $one_way = null) {
+    public function __doRequest($request, $location, $action, $version, $one_way = null): ?string {
 
         $http_headers = array(
             'Content-type: text/xml;charset="utf-8"',


### PR DESCRIPTION
With PHP 8.1 we get a warning that the output of the method needs to match the parent method.
Fix is backwards compatible.
