### PR TITLE
forcing array type before using current()

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -251,7 +251,7 @@ function turnitintooltwo_grade_item_update($turnitintooltwo, $grades = null) {
 
     // Get the latest part, for the post date and set the default hidden value on grade item.
     $lastpart = $DB->get_record('turnitintooltwo_parts', array('turnitintooltwoid' => $turnitintooltwo->id), 'max(dtpost)');
-    $lastpart = current($lastpart);
+    $lastpart = current((array)$lastpart);
     $params['hidden'] = $lastpart;
 
     // There should always be a $cm unless this is called on module creation.
@@ -1546,7 +1546,7 @@ function turnitintooltwo_init_browser_assignment_table($tiicourseid) {
                         );
 
     if (!empty($turnitincourse)) {
-        $course = current($turnitincourse);
+        $course = current((array)$turnitincourse);
         $coursedetails = turnitintooltwo_assignment::get_course_data($course->courseid, $course->course_type);
         $courseid = $course->courseid;
         $coursetitle = $coursedetails->fullname;


### PR DESCRIPTION
Applying current to an object is now deprecated.
Forcing type array before will solve this.
